### PR TITLE
Add MOS2025 talk announcement

### DIFF
--- a/_news/announcement_mos2025_talk.md
+++ b/_news/announcement_mos2025_talk.md
@@ -1,0 +1,9 @@
+---
+layout: post
+date: 2025-05-01 09:00:00-0000
+inline: true
+related_posts: false
+---
+
+I will give a talk titled 'Auto-Formulating Dynamic Programming Problems with Large Language Models' at MOS2025.
+


### PR DESCRIPTION
## Summary
- add MOS2025 talk announcement to news

## Testing
- `pre-commit run --files _news/announcement_mos2025_talk.md` *(fails: command not found)*
- `bundle exec jekyll build` *(fails: command not found)*