### PR TITLE
Add paper links and abstract placeholders

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -19,6 +19,7 @@
   author    = {Hongzhou Chen and Chenyu Zhou and Abdulmotaleb El Saddik and Wei Cai},
   booktitle = {The 27th ACM SIGCHI Conference on Computer-Supported Cooperative Work & Social Computing},
   series    = {CSCW '24},
+  abstract  = {TBD},
   year      = {2024},
   selected  = {true}
 }
@@ -29,6 +30,7 @@
   author    = {Chenyu Zhou and Hongzhou Chen and Hao Wu and Junyu Zhang and Wei Cai},
   booktitle = {The 2024 ACM Web Conference (Oral)},
   series    = {WWW '24},
+  paper     = {https://dl.acm.org/doi/10.1145/3589334.3645597},
   code      = {https://doi.org/10.5281/zenodo.10676801},
   abstract  = {As Web3 projects leverage airdrops to incentivize participation, airdrop hunters tactically amass wallet addresses to capitalize on token giveaways. This poses challenges to the decentralization goal. Current detection approaches tailored for cryptocurrencies overlook non-fungible tokens (NFTs) nuances. We introduce ARTEMIS, an optimized graph neural network system for identifying airdrop hunters in NFT transactions. ARTEMIS captures NFT airdrop hunters through: (1) a multimodal module extracting visual and textual insights from NFT metadata using Transformer models; (2) a tailored node aggregation function chaining NFT transaction sequences, retaining behavioral insights; (3) engineered features based on market manipulation theories detecting anomalous trading. Evaluated on decentralized exchange Blur's data, ARTEMIS significantly outperforms baselines in pinpointing hunters. This pioneering computational solution for an emergent Web3 phenomenon has broad applicability for blockchain anomaly detection. The data and code for the paper are accessible at the following link: doi.org/10.5281/zenodo.10676801.},
   year      = {2024},
@@ -40,6 +42,7 @@
   abbr     = {IEEE Wirel Commun},
   author   = {Chenyu Zhou and Hongzhou Chen and Shiman Wang and Xinyao Sun and Abdulmotaleb El Saddik and Wei Cai},
   journal  = {IEEE Wireless Communications},
+  paper     = {https://arxiv.org/abs/2308.02039},
   title    = {Harnessing Web3 on Carbon Offset Market for Sustainability: Framework and A Case Study},
   abstract = {Blockchain, pivotal in shaping the metaverse and Web3, often draws criticism for high energy consumption and carbon emission. The rise of sustainability-focused blockchains, especially when intersecting with innovative wireless technologies, revises this predicament. To understand blockchain's role in sustainability, we propose a three-layers structure encapsulating four green utilities: Recording and Tracking, Wide Verification, Value Trading, and Concept Disseminating. Nori, a decentralized voluntary carbon offset project, serves as our case, illuminating these utilities. Our research unveils unique insights into the on-chain carbon market participants, affect factors of the market, value propositions of {NFT}-based carbon credits, and the role of social media to spread the concept of carbon offset. We argue that blockchain's contribution to sustainability is significant, with carbon offsetting potentially evolving as a new standard within the blockchain sector.},
   arxiv    = {2308.02039},

--- a/_config.yml
+++ b/_config.yml
@@ -363,6 +363,7 @@ filtered_bibtex_keywords:
     blog,
     code,
     html,
+    paper,
     pdf,
     poster,
     preview,

--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -205,6 +205,13 @@
           <a href="{{ entry.html | prepend: '/assets/html/' | relative_url }}" class="btn btn-sm z-depth-0" role="button">HTML</a>
         {% endif %}
       {% endif %}
+      {% if entry.paper %}
+        {% if entry.paper contains '://' %}
+          <a href="{{ entry.paper }}" class="btn btn-sm z-depth-0" role="button">Paper</a>
+        {% else %}
+          <a href="{{ entry.paper | prepend: '/assets/pdf/' | relative_url }}" class="btn btn-sm z-depth-0" role="button">Paper</a>
+        {% endif %}
+      {% endif %}
       {% if entry.pdf %}
         {% if entry.pdf contains '://' %}
           <a href="{{ entry.pdf }}" class="btn btn-sm z-depth-0" role="button">PDF</a>


### PR DESCRIPTION
## Summary
- add new `paper` field support in publications layout
- hide the new field in Jekyll Scholar config
- include official paper links and placeholder abstract in bibliography

## Testing
- `pre-commit run --files _config.yml _layouts/bib.liquid _bibliography/papers.bib` *(fails: command not found)*